### PR TITLE
LOG-11043 Remove structures and fix tests

### DIFF
--- a/src/le.py
+++ b/src/le.py
@@ -3332,7 +3332,7 @@ def is_log_fs(addr):
     return False
 
 
-def cmd_ls_ips(ags):
+def cmd_ls_ips():
     """
     List IPs used by the agent.
     """
@@ -3351,7 +3351,7 @@ def cmd_ls(args):
     General list command
     """
     if len(args) == 1 and args[0] == 'ips':
-        cmd_ls_ips(args)
+        cmd_ls_ips()
         return
     if len(args) == 0:
         args = ['/']

--- a/src/le.py
+++ b/src/le.py
@@ -70,10 +70,7 @@ LE_SERVER_API = '/'
 LE_DEFAULT_SSL_PORT = 20000
 LE_DEFAULT_NON_SSL_PORT = 10000
 
-# Maximal pattern priority
-MAX_PATTERN_PRIORITY = 100000
-
-# Structures embedded (technology preview)
+# Structures embedded (beta)
 EMBEDDED_STRUCTURES = {
     # JSON with support for nested objects
     "json": "444e607f-14bd-405e-a2ce-c4892b5a3b15",
@@ -212,22 +209,6 @@ Where command is one of:
   ls        List internal filesystem and settings: <path>
   rm        Remove entity: <path>
   pull      Pull log file: <path> <when> <filter> <limit>
-
-  Structure management (technology preview)
-  ls structures          List structures defined
-  add structure <name>
-  add structures/<name>  Add a new structure
-  rm structure <name>
-  rm structures/<name>   Remove a structure
-  add structures/<name> <pattern> [priority]
-    Add a pattern in a structure
-    name          structure name
-    pattern       pattern
-    priority      priority of the pattern (defining ordering)
-  rm structures/<name> <pattern>
-                         Remove a pattern from structure
-    name          structure name
-    pattern       pattern to remove, alternatively beginning or ID of a pattern to remove
 
 Where parameters are:
   --help                  show usage help and exit
@@ -2198,7 +2179,7 @@ class Config(object):
         param_list = """user-key= account-key= agent-key= host-key= no-timestamps debug-events
                     debug-transport-events debug-metrics
                     debug-filters debug-formatters debug-loglist local debug-stats debug-nostats
-                    debug-stats-only debug-cmd-line debug-system help version yes force id uuid list
+                    debug-stats-only debug-cmd-line debug-system help version yes force uuid list
                     std std-all name= hostname= type= pid-file= debug no-defaults
                     suppress-ssl use-ca-provided force-api-host= force-domain=
                     system-stat-token= datahub=
@@ -2230,8 +2211,6 @@ class Config(object):
                 self.force = True
             elif name == "--list":
                 self.xlist = True
-            elif name == "--id":
-                self.uuid = True
             elif name == "--uuid":
                 self.uuid = True
             elif name == "--name":
@@ -2361,9 +2340,8 @@ def api_request(request, required=False, check_status=False, silent=False, die_o
     Processes a request on the logentries domain.
     """
     # Obtain response
-    request_encoded = urllib.urlencode(request)
     response, conn = get_response(
-        "POST", LE_SERVER_API, request_encoded,
+        "POST", LE_SERVER_API, urllib.urlencode(request),
         silent=silent, die_on_error=die_on_error, domain=Domain.API,
         headers={'Content-Type': 'application/x-www-form-urlencoded'})
 
@@ -2405,57 +2383,6 @@ def api_request(request, required=False, check_status=False, silent=False, die_o
         else:
             log.info(error)
             d_response = None
-
-    return d_response
-
-
-
-def api_v2_request(method, url, request, required=False, silent=False, die_on_error=True):
-    """
-    Processes a request on the logentries domain.
-    """
-    # Obtain response
-    request_encoded = json.dumps(request)
-    response, conn = get_response(
-        method, '/v2/accounts/%s/%s'%(config.user_key, url), request_encoded,
-        silent=silent, die_on_error=die_on_error, domain=Domain.API,
-        headers={'Content-Type': 'application/x-www-form-urlencoded'})
-
-    # Check the response
-    if not response:
-        if required:
-            error("Cannot process LE request, no response")
-        if conn:
-            conn.close()
-        return None
-
-    xresponse = response.read()
-    conn.close()
-
-    log.debug('Domain response: "%s"', xresponse)
-    try:
-        if xresponse:
-            d_response = json_loads(xresponse)
-        else:
-            d_response = {}
-    except ValueError:
-        error = 'Error: Invalid response, parse error.'
-        if die_on_error:
-            die(error)
-        else:
-            log.info(error)
-            d_response = None
-
-    if response.status not in [httplib.OK, httplib.CREATED, httplib.NO_CONTENT]:
-        reason = ''
-        if 'reason' in d_response:
-            reason = d_response['reason']
-        if required:
-            if reason:
-                error("%s" % reason)
-            else:
-                error("Cannot process LE request: (%s)", response.status)
-        return None
 
     return d_response
 
@@ -3405,7 +3332,7 @@ def is_log_fs(addr):
     return False
 
 
-def cmd_ls_ips():
+def cmd_ls_ips(ags):
     """
     List IPs used by the agent.
     """
@@ -3419,81 +3346,12 @@ def cmd_ls_ips():
     print ' '.join(l)
 
 
-def cmd_ls_structures():
-    """
-    List user defined structures.
-    """
-    config.load()
-    config.user_key_required(True)
-
-    response = api_v2_request('GET', 'structures', {}, True)
-    structures = response['structures']
-
-    structures = response['structures']
-    for structure in sorted(structures, key=lambda x: x['name']):
-        if config.uuid:
-            print c_id(structure['id']),
-        print structure['name']
-
-    if len(structures) == 0:
-        print >> sys.stderr, 'No structures defined'
-    elif len(structures) == 1:
-        print >> sys.stderr, '1 structure'
-    else:
-        print >> sys.stderr, '%s structures' % len(structures)
-
-
-def cmd_ls_patterns(structure_name):
-    """
-    Lists patterns associated with the structure given.
-    """
-    if not structure_name:
-        error('Structure name not specified')
-
-    config.load()
-    config.user_key_required(True)
-
-    response = api_v2_request('GET', 'structures', {}, True)
-    structures = response['structures']
-
-    # Find structure
-    matches = [s['id'] for s in structures if structure_name.lower() == s['id'].lower() or structure_name == s['name']]
-    if len(matches) == 0:
-        error('Structure `%s\' does not exist', structure_name)
-    if len(matches) > 1:
-        error('Multiple matches for `%s\'', structure_name)
-    structure_id = matches[0]
-
-    response = api_v2_request('GET', 'structures/%s/patterns'%structure_id, {}, True)
-
-    patterns = response['patterns']
-    for pattern in sorted(patterns, cmp=cmp_patterns):
-        if config.uuid:
-            print c_id(pattern['id']),
-        print '%2d %s' % (pattern['priority'], pattern['pattern'])
-    if len(patterns) == 0:
-        print >> sys.stderr, 'No patterns in structure `%s\'' % structure_name
-    elif len(patterns) == 1:
-        print >> sys.stderr, '1 pattern'
-    else:
-        print >> sys.stderr, '%s patterns' % len(patterns)
-
-
 def cmd_ls(args):
     """
     General list command
     """
     if len(args) == 1 and args[0] == 'ips':
-        cmd_ls_ips()
-        return
-    if len(args) == 1 and args[0] == 'structures':
-        cmd_ls_structures()
-        return
-    if len(args) >= 1 and args[0].startswith('structures/'):
-        if len(args) == 1:
-            cmd_ls_patterns(args[0][len('structures/'):])
-        else:
-            die('Error: Too many arguments.')
+        cmd_ls_ips(args)
         return
     if len(args) == 0:
         args = ['/']
@@ -3513,182 +3371,12 @@ def cmd_ls(args):
                 hostnames=addr.startswith('hostnames'))
 
 
-def cmd_add_structure(args):
-    """
-    Add a new structure command.
-
-    Args:
-        args: structure name followed by (optionally) pattern and priority
-    """
-    if not args:
-        error('No structure name specified')
-    structure_name = args[0].strip()
-    if not structure_name:
-        error('Empty structure name')
-
-    pattern = ''
-    priority = -1
-
-    # Get and check the pattern
-    if len(args) > 1:
-        pattern = args[1]
-        if not pattern:
-            error('Pattern in empty')
-
-    if len(args) > 2:
-        try:
-            priority = int(args[2])
-            if priority < 0:
-                error('Priority must be positive')
-            if priority > MAX_PATTERN_PRIORITY:
-                error('Priority `%s\'is above the limit (%s)', args[2], MAX_PATTERN_PRIORITY)
-        except ValueError:
-            error('Invalid priority `%s\', must be a positive integer', args[2])
-
-    if len(args) > 3:
-        error('Too many arguments')
-
-    config.load()
-    config.user_key_required(True)
-
-    # Get all structures
-    response = api_v2_request('GET', 'structures', {}, True)
-    structures = response['structures']
-
-    # Find the structure
-    matches = [s['id'] for s in structures if structure_name.lower() == s['id'].lower() or structure_name == s['name']]
-    if len(matches) == 0:
-        # Add the structure
-        response = api_v2_request('POST', 'structures', {
-            'name': structure_name,
-            'shortcut': structure_name,
-            'description': '',
-            'aux': {},
-            }, True)
-        print >> sys.stderr, 'Added structure `%s\'' % structure_name
-        structure_id = response['structure']['id']
-    else:
-        structure_id = matches[0]
-        if not pattern:
-            print >> sys.stderr, 'Structure `%s\' already exists' % structure_name
-
-    # Add pattern (if specified)
-    # TODO - check that the pattern does not exist already
-    if pattern:
-        response = api_v2_request('POST', 'structures/%s/patterns'%structure_id, {
-            'priority': priority,
-            'pattern': pattern,
-            }, True)
-        print >> sys.stderr, 'Added pattern `%s\'' % pattern
-
-
-def cmd_add(args):
-    """
-    General add command.
-    """
-    if len(args) >= 1 and args[0] == 'structure':
-        cmd_add_structure(args[1:])
-    elif len(args) >= 1 and args[0].startswith('structures/'):
-        cmd_add_structure([args[0][len('structures/'):]] + args[1:])
-    elif len(args) == 0:
-        error('Specify what to add, i.e. structure')
-    else:
-        error('Unknown item to add: `%s\'', args[0])
-
-
-def cmd_rm_pattern(patterns, structure_name, structure_id):
-    if not patterns:
-        error('No pattern specified (append pattern ID or beginning of the pattern or .) to remove.')
-    if len(patterns) > 1:
-        error('Too many arguments, only one pattern allowed')
-    pattern = patterns[0]
-
-    rm_all = pattern in ['*', '.']
-
-    # Load all patterns
-    response = api_v2_request('GET', 'structures/%s/patterns'%structure_id, {}, True)
-    patterns = response['patterns']
-
-    # Go though patterns one by one, identify pattern IDs
-    # Use a different call for pattern=*
-    matches = [[p['id'], p['pattern']] for p in patterns \
-            if rm_all or p['id'] == pattern or p['pattern'].startswith(pattern)]
-    if not matches:
-        if rm_all:
-            print >> sys.stderr, 'No pattern to be removed; structure is empty'
-        else:
-            error('No pattern matching `%s\' found', pattern)
-    if len(matches) > 1 and not rm_all:
-        error('Pattern `%s\' is not specific enough; multiple matches', pattern)
-
-    # Do the physical deletion
-    for pattern_id, pattern_p in matches:
-        response = api_v2_request('DELETE', 'structures/%s/patterns/%s'%(structure_id, pattern_id), {}, True)
-        print >> sys.stderr, 'Removed pattern `%s\'' % pattern_p
-
-
-def cmd_rm_structure(args):
-    """ Remove the structure (or pattern) command.
-
-    Arguments contain command line (including 'structure' at the beginning)
-    """
-    subject = args[0]
-    structure_name = ''
-    if subject == 'structures':
-        # We don't support removing structures
-        error('Invalid command. Use `rm structure name\' or `rm structures/name\'')
-    if subject == 'structure':
-        if len(args) == 1:
-            error('No structure name specified (append structure name)')
-        if len(args) > 2:
-            error('Too many structure names specified (specify only one name)')
-        structure_name = args[1]
-        patterns = args[2:]
-    elif subject.startswith('structures/'):
-        structure_name = subject[len('structures/'):]
-        patterns = args[1:]
-
-    if not structure_name:
-        error('No structure name specified (append structure name)')
-
-    # Note args contain structure name or ID, and an optional pattern
-
-    config.load()
-    config.user_key_required(True)
-
-    # Load all structures
-    response = api_v2_request('GET', 'structures', {}, True)
-    structures = response['structures']
-
-    # Find structure IDs
-    structure = [[structure_name, s['id']] for s in structures if structure_name.lower() == s['id'].lower() or structure_name == s['name']]
-    if not structure:
-        error('Structure `%s\' does not exist', structure_name)
-    if len(structure) > 1:
-        error('Multiple matches for `%s\'', structure_name)
-    structure_id = structure[0][1]
-
-    # Now we know structure exists and we know its ID
-
-    if not patterns: # Removing structure
-        response = api_v2_request('DELETE', 'structures/%s'%structure_id, {}, True)
-        print >> sys.stderr, 'Removed structure `%s\'' % structure_name
-    else: # Removing patterns
-        cmd_rm_pattern(patterns, structure_name, structure_id)
-
-
 def cmd_rm(args):
     """
     General remove command
     """
-    # In case of removing structures and patterns
-    if args and (args[0] in ['structure', 'structures'] or args[0].startswith('structures/')):
-        cmd_rm_structure(args)
-        return
-
-    if not args:
+    if len(args) == 0:
         args = ['/']
-
     config.load()
     config.user_key_required(True)
 
@@ -3778,12 +3466,9 @@ def main_root():
         'followed': cmd_followed,
         'clean': cmd_clean,
         'whoami': cmd_whoami,
-        'add': cmd_add,
         # Filesystem operations
         'ls': cmd_ls,
-        'list': cmd_ls,
         'rm': cmd_rm,
-        'remove': cmd_rm,
         'pull': cmd_pull,
     }
     for cmd, func in commands.items():

--- a/src/utils.py
+++ b/src/utils.py
@@ -17,33 +17,14 @@ from backports import match_hostname, CertificateError
 
 import logging
 
-try:
-    import termcolor
-    colored = termcolor.colored
-except ImportError:
-    def colored(text, color):
-        return text
-
-def red(text):
-    return colored('%s'%text, 'red')
-
-def c_param(text):
-    return colored('%s'%text, 'green')
-
-def c_id(text):
-    return colored('%s'%text, 'cyan')
-
-
 
 __author__ = 'Logentries'
 
 __all__ = ["EXIT_OK", "EXIT_NO", "EXIT_HELP", "EXIT_ERR", "EXIT_TERMINATED",
            "ServerHTTPSConnection", "LOG_LE_AGENT", "create_conf_dir",
            "default_cert_file", "system_cert_file", "domain_connect",
-           "no_more_args", "find_hosts", "find_logs", "find_api_obj_by_key", "find_api_obj_by_name", "die",
-           "error", "cmp_patterns",
-           "rfile", 'TCP_TIMEOUT', "rm_pidfile", "uuid_parse", "report",
-           "colored", "c_param", "c_id"]
+           "no_more_args", "find_hosts", "find_logs", "find_api_obj_by_key", "find_api_obj_by_name",
+           "die", "error", "colored", "rfile", 'TCP_TIMEOUT', "rm_pidfile", "uuid_parse", "report"]
 
 # Return codes
 EXIT_OK = 0
@@ -412,9 +393,6 @@ def die(cause, exit_code=EXIT_ERR):
     log.critical('%s', cause)
     sys.exit(exit_code)
 
-def error(cause, *args):
-    die(red('Error:' + ' ' + cause%args))
-
 
 def rfile(name):
     """
@@ -473,19 +451,15 @@ def get_bundled_certs():
     with open(file_name) as r:
         return r.read()
 
+try:
+    import termcolor
+    colored = termcolor.colored
+except ImportError:
+    def colored(text, color):
+        return text
 
-def cmp_patterns(a, b):
-    """
-    Intuitive comparison of two patterns.
-    """
-    v = cmp(a['priority'], b['priority'])
-    if v == 0:
-        ap = a['pattern'].lower()
-        if ap.endswith('/'):
-            ap = ap[:-1]
-        bp = b['pattern'].lower()
-        if bp.endswith('/'):
-            bp = bp[:-1]
-        v = cmp(ap, bp)
-    return v
+def red(text):
+    return colored('%s'%text, 'red')
 
+def error(cause, *args):
+    die(red('Error:' + ' ' + cause%args))

--- a/src/utils.py
+++ b/src/utils.py
@@ -390,7 +390,7 @@ def find_api_obj_by_key(obj_list, key):
 
 
 def die(cause, exit_code=EXIT_ERR):
-    log.critical('%s', cause)
+    log.critical('\n%s', cause)
     sys.exit(exit_code)
 
 

--- a/test/tests.d/bw_server_side_http_put.sh
+++ b/test/tests.d/bw_server_side_http_put.sh
@@ -32,8 +32,8 @@ Testcase 'Register'
 $LE register --name Name --hostname Hostname
 #e Configuration files loaded: sandbox_config
 #e Connecting to 127.0.0.1:8081
-#e Domain request: POST / distver=%DEBIAN_VERSION_ENC%&name=Name&distname=Debian&hostname=Hostname&request=register&system=Linux&user_key=f720fe54-879a-11e4-81ac-277d856f873e {'Content-Type': 'application/x-www-form-urlencoded'}
-#e Domain response: "{"host": {"distver": "%DEBIAN_VERSION%", "c": 1315863111149, "hostname": "Hostname", "name": "Name", "distname": "Debian", "object": "host", "key": "41ae887a-284a-4d78-91fe-56485b076148"}, "agent_key": "41ae887a-284a-4d78-91fe-56485b076148", "host_key": "41ae887a-284a-4d78-91fe-56485b076148", "worker": "a0", "response": "ok"}"
+#e Domain request: POST / distver=%DEBIAN_VERSION_ENC%&name=Name&distname=%DIST_NAME%&hostname=Hostname&request=register&system=Linux&user_key=f720fe54-879a-11e4-81ac-277d856f873e {'Content-Type': 'application/x-www-form-urlencoded'}
+#e Domain response: "{"host": {"distver": "%DEBIAN_VERSION%", "c": 1315863111149, "hostname": "Hostname", "name": "Name", "distname": "%DIST_NAME%", "object": "host", "key": "41ae887a-284a-4d78-91fe-56485b076148"}, "agent_key": "41ae887a-284a-4d78-91fe-56485b076148", "host_key": "41ae887a-284a-4d78-91fe-56485b076148", "worker": "a0", "response": "ok"}"
 #e Registered Name (Hostname)
 
 Testcase 'Follow'

--- a/test/tests.sh
+++ b/test/tests.sh
@@ -19,8 +19,9 @@ trap finish EXIT
 export AUTO_TEST='yes'
 
 declare -A TEMPLATES
-[ -f /etc/debian_version ] && TEMPLATES[DEBIAN_VERSION]="$(cat /etc/debian_version)"
-[ -f /etc/debian_version ] && TEMPLATES[DEBIAN_VERSION_ENC]="${TEMPLATES[DEBIAN_VERSION]/\//%2F}"
+TEMPLATES[DEBIAN_VERSION]="$(lsb_release -sr)"
+TEMPLATES[DEBIAN_VERSION_ENC]="${TEMPLATES[DEBIAN_VERSION]/\//%2F}"
+TEMPLATES[DIST_NAME]="$(lsb_release -si)"
 
 # Run tests one by one
 for A in ${TESTS[*]} ; do


### PR DESCRIPTION
This story is about getting the LE agent back into a state where it can be released, and fixing some of the tests.

Structures have been present in the repository for a while, but were never released. So I was asked to remove them.

Other fixes and improvements that were made in the meantime were kept.

Build log:
```
Cloning into 'logentries'...
remote: Counting objects: 3467, done.
remote: Compressing objects: 100% (11/11), done.
remote: Total 3467 (delta 4), reused 7 (delta 4), pack-reused 3452
Receiving objects: 100% (3467/3467), 5.30 MiB | 3.89 MiB/s, done.
Resolving deltas: 100% (2106/2106), done.
Checking connectivity... done.
'src/cacert.pem' -> 'ca-certs.pem'
Branch LOG-11043 set up to track remote branch LOG-11043 from origin.
Switched to a new branch 'LOG-11043'
 dpkg-buildpackage -rfakeroot -d -us -uc -a
dpkg-buildpackage: source package logentries
dpkg-buildpackage: source version 1.4.41
dpkg-buildpackage: source distribution wheezy jessie trusty vivid wily xenial
dpkg-buildpackage: source changed by Mr Jenkins <jenkins@logentries.com>
 dpkg-source --before-build logentries
dpkg-buildpackage: host architecture amd64
 fakeroot debian/rules clean
dh clean --with python2
   dh_testdir
   dh_auto_clean
	python setup.py clean -a
running clean
'build/lib.linux-x86_64-2.7' does not exist -- can't clean it
'build/bdist.linux-x86_64' does not exist -- can't clean it
'build/scripts-2.7' does not exist -- can't clean it
	find . -name \*.pyc -exec rm {} \+
   dh_clean
 dpkg-source -b logentries
dpkg-source: warning: no source format specified in debian/source/format, see dpkg-source(1)
dpkg-source: warning: source directory 'logentries' is not <sourcepackage>-<upstreamversion> 'logentries-1.4.41'
dpkg-source: info: using source format '1.0'
dpkg-source: info: building logentries in logentries_1.4.41.tar.gz
dpkg-source: info: building logentries in logentries_1.4.41.dsc
 debian/rules build
dh build --with python2
   dh_testdir
   dh_update_autotools_config
   dh_auto_configure
   dh_auto_build
	python setup.py build --force
running build
running build_py
creating build
creating build/lib.linux-x86_64-2.7
creating build/lib.linux-x86_64-2.7/logentries
copying src/__init__.py -> build/lib.linux-x86_64-2.7/logentries
copying src/formats.py -> build/lib.linux-x86_64-2.7/logentries
copying src/le.py -> build/lib.linux-x86_64-2.7/logentries
copying src/socks.py -> build/lib.linux-x86_64-2.7/logentries
copying src/backports.py -> build/lib.linux-x86_64-2.7/logentries
copying src/metrics.py -> build/lib.linux-x86_64-2.7/logentries
copying src/utils.py -> build/lib.linux-x86_64-2.7/logentries
   debian/rules override_dh_auto_test
make[1]: Entering directory '/home/vagrant/agent_repos/compile/logentries'
cd test ; [ ! -d env ] && virtualenv env && env/bin/pip install -r requirements.pip ; ./tests.sh
New python executable in /home/vagrant/agent_repos/compile/logentries/test/env/bin/python2
Also creating executable in /home/vagrant/agent_repos/compile/logentries/test/env/bin/python
Installing setuptools, pkg_resources, pip, wheel...done.
Running virtualenv with interpreter /usr/bin/python2
Collecting cyclone==1.1 (from -r requirements.pip (line 1))
Collecting pyopenssl (from cyclone==1.1->-r requirements.pip (line 1))
  Using cached https://files.pythonhosted.org/packages/79/db/7c0cfe4aa8341a5fab4638952520d8db6ab85ff84505e12c00ea311c3516/pyOpenSSL-17.5.0-py2.py3-none-any.whl
Collecting twisted (from cyclone==1.1->-r requirements.pip (line 1))
Collecting cryptography>=2.1.4 (from pyopenssl->cyclone==1.1->-r requirements.pip (line 1))
  Using cached https://files.pythonhosted.org/packages/dd/c2/3a5bfefb25690725824ade71e6b65449f0a9f4b29702cce10560f786ebf6/cryptography-2.2.2-cp27-cp27mu-manylinux1_x86_64.whl
Collecting six>=1.5.2 (from pyopenssl->cyclone==1.1->-r requirements.pip (line 1))
  Using cached https://files.pythonhosted.org/packages/67/4b/141a581104b1f6397bfa78ac9d43d8ad29a7ca43ea90a2d863fe3056e86a/six-1.11.0-py2.py3-none-any.whl
Collecting hyperlink>=17.1.1 (from twisted->cyclone==1.1->-r requirements.pip (line 1))
  Using cached https://files.pythonhosted.org/packages/a7/b6/84d0c863ff81e8e7de87cff3bd8fd8f1054c227ce09af1b679a8b17a9274/hyperlink-18.0.0-py2.py3-none-any.whl
Collecting constantly>=15.1 (from twisted->cyclone==1.1->-r requirements.pip (line 1))
  Using cached https://files.pythonhosted.org/packages/b9/65/48c1909d0c0aeae6c10213340ce682db01b48ea900a7d9fce7a7910ff318/constantly-15.1.0-py2.py3-none-any.whl
Collecting incremental>=16.10.1 (from twisted->cyclone==1.1->-r requirements.pip (line 1))
  Using cached https://files.pythonhosted.org/packages/f5/1d/c98a587dc06e107115cf4a58b49de20b19222c83d75335a192052af4c4b7/incremental-17.5.0-py2.py3-none-any.whl
Collecting zope.interface>=4.4.2 (from twisted->cyclone==1.1->-r requirements.pip (line 1))
Collecting Automat>=0.3.0 (from twisted->cyclone==1.1->-r requirements.pip (line 1))
  Using cached https://files.pythonhosted.org/packages/17/6a/1baf488c2015ecafda48c03ca984cf0c48c254622668eb1732dbe2eae118/Automat-0.6.0-py2.py3-none-any.whl
Collecting cffi>=1.7; platform_python_implementation != "PyPy" (from cryptography>=2.1.4->pyopenssl->cyclone==1.1->-r requirements.pip (line 1))
  Using cached https://files.pythonhosted.org/packages/14/dd/3e7a1e1280e7d767bd3fa15791759c91ec19058ebe31217fe66f3e9a8c49/cffi-1.11.5-cp27-cp27mu-manylinux1_x86_64.whl
Collecting enum34; python_version < "3" (from cryptography>=2.1.4->pyopenssl->cyclone==1.1->-r requirements.pip (line 1))
  Using cached https://files.pythonhosted.org/packages/c5/db/e56e6b4bbac7c4a06de1c50de6fe1ef3810018ae11732a50f15f62c7d050/enum34-1.1.6-py2-none-any.whl
Collecting asn1crypto>=0.21.0 (from cryptography>=2.1.4->pyopenssl->cyclone==1.1->-r requirements.pip (line 1))
  Using cached https://files.pythonhosted.org/packages/ea/cd/35485615f45f30a510576f1a56d1e0a7ad7bd8ab5ed7cdc600ef7cd06222/asn1crypto-0.24.0-py2.py3-none-any.whl
Collecting idna>=2.1 (from cryptography>=2.1.4->pyopenssl->cyclone==1.1->-r requirements.pip (line 1))
  Using cached https://files.pythonhosted.org/packages/27/cc/6dd9a3869f15c2edfab863b992838277279ce92663d334df9ecf5106f5c6/idna-2.6-py2.py3-none-any.whl
Collecting ipaddress; python_version < "3" (from cryptography>=2.1.4->pyopenssl->cyclone==1.1->-r requirements.pip (line 1))
  Using cached https://files.pythonhosted.org/packages/fc/d0/7fc3a811e011d4b388be48a0e381db8d990042df54aa4ef4599a31d39853/ipaddress-1.0.22-py2.py3-none-any.whl
Requirement already satisfied: setuptools in ./env/lib/python2.7/site-packages (from zope.interface>=4.4.2->twisted->cyclone==1.1->-r requirements.pip (line 1)) (39.1.0)
Collecting attrs (from Automat>=0.3.0->twisted->cyclone==1.1->-r requirements.pip (line 1))
  Using cached https://files.pythonhosted.org/packages/41/59/cedf87e91ed541be7957c501a92102f9cc6363c623a7666d69d51c78ac5b/attrs-18.1.0-py2.py3-none-any.whl
Collecting pycparser (from cffi>=1.7; platform_python_implementation != "PyPy"->cryptography>=2.1.4->pyopenssl->cyclone==1.1->-r requirements.pip (line 1))
Installing collected packages: pycparser, cffi, enum34, asn1crypto, idna, six, ipaddress, cryptography, pyopenssl, hyperlink, constantly, incremental, zope.interface, attrs, Automat, twisted, cyclone
Successfully installed Automat-0.6.0 asn1crypto-0.24.0 attrs-18.1.0 cffi-1.11.5 constantly-15.1.0 cryptography-2.2.2 cyclone-1.1 enum34-1.1.6 hyperlink-18.0.0 idna-2.6 incremental-17.5.0 ipaddress-1.0.22 pycparser-2.18 pyopenssl-17.5.0 six-1.11.0 twisted-18.4.0 zope.interface-4.5.0
tests.d/bw_client_side_configuration.sh
tests.d/bw_server_side_http_put.sh
tests.d/configuration_dir.sh
tests.d/configuration_multi_dirs.sh
tests.d/configuration.sh
tests.d/entry_identifier.py
tests.d/formatters_custom.sh
tests.d/formatters.sh
tests.d/formatters_user.sh
tests.d/help.sh
tests.d/listings.sh
tests.d/log_config_create.sh
tests.d/multilog_configuration.sh
tests.d/multilog_dynamic.sh
tests.d/multilog_pathname_verification.sh
tests.d/multilog_workflow.sh
tests.d/state_file.sh
tests.d/unicode.sh
SUCCESS
make[1]: Leaving directory '/home/vagrant/agent_repos/compile/logentries'
 fakeroot debian/rules binary
dh binary --with python2
   dh_testroot
   dh_prep
   dh_installdirs
   debian/rules override_dh_auto_install
make[1]: Entering directory '/home/vagrant/agent_repos/compile/logentries'
python setup.py install --root=debian/logentries --install-layout=deb --install-lib=/usr/share/logentries --install-scripts=/usr/share/logentries
running install
running build
running build_py
running install_lib
creating debian/logentries/usr/share
creating debian/logentries/usr/share/logentries
creating debian/logentries/usr/share/logentries/logentries
copying build/lib.linux-x86_64-2.7/logentries/__init__.py -> debian/logentries/usr/share/logentries/logentries
copying build/lib.linux-x86_64-2.7/logentries/formats.py -> debian/logentries/usr/share/logentries/logentries
copying build/lib.linux-x86_64-2.7/logentries/le.py -> debian/logentries/usr/share/logentries/logentries
copying build/lib.linux-x86_64-2.7/logentries/socks.py -> debian/logentries/usr/share/logentries/logentries
copying build/lib.linux-x86_64-2.7/logentries/backports.py -> debian/logentries/usr/share/logentries/logentries
copying build/lib.linux-x86_64-2.7/logentries/metrics.py -> debian/logentries/usr/share/logentries/logentries
copying build/lib.linux-x86_64-2.7/logentries/utils.py -> debian/logentries/usr/share/logentries/logentries
byte-compiling debian/logentries/usr/share/logentries/logentries/__init__.py to __init__.pyc
byte-compiling debian/logentries/usr/share/logentries/logentries/formats.py to formats.pyc
byte-compiling debian/logentries/usr/share/logentries/logentries/le.py to le.pyc
byte-compiling debian/logentries/usr/share/logentries/logentries/socks.py to socks.pyc
byte-compiling debian/logentries/usr/share/logentries/logentries/backports.py to backports.pyc
byte-compiling debian/logentries/usr/share/logentries/logentries/metrics.py to metrics.pyc
byte-compiling debian/logentries/usr/share/logentries/logentries/utils.py to utils.pyc
running install_egg_info
running egg_info
creating logentries.egg-info
writing logentries.egg-info/PKG-INFO
writing top-level names to logentries.egg-info/top_level.txt
writing dependency_links to logentries.egg-info/dependency_links.txt
writing entry points to logentries.egg-info/entry_points.txt
writing manifest file 'logentries.egg-info/SOURCES.txt'
reading manifest file 'logentries.egg-info/SOURCES.txt'
writing manifest file 'logentries.egg-info/SOURCES.txt'
Copying logentries.egg-info to debian/logentries/usr/share/logentries/logentries-1.4.42.egg-info
Skipping SOURCES.txt
running install_scripts
Installing le script to debian/logentries/usr/share/logentries
make[1]: Leaving directory '/home/vagrant/agent_repos/compile/logentries'
   dh_install
   dh_installdocs
   dh_installchangelogs
   dh_python2
   dh_perl
   dh_link
   dh_strip_nondeterminism
   dh_compress
   dh_fixperms
   dh_installdeb
   dh_gencontrol
   dh_md5sums
   dh_builddeb
dpkg-deb: building package 'logentries' in '../logentries_1.4.41_all.deb'.
 dpkg-genchanges  >../logentries_1.4.41_amd64.changes
dpkg-genchanges: including full source code in upload
 dpkg-source --after-build logentries
dpkg-buildpackage: full upload; Debian-native package (full source is included)
Now running lintian...
E: logentries changes: bad-distribution-in-changes-file wheezy
E: logentries changes: bad-distribution-in-changes-file jessie
E: logentries changes: multiple-distributions-in-changes-file wheezy jessie trusty vivid wily xenial
W: logentries source: ancient-standards-version 3.9.1 (current is 3.9.7)
E: logentries: package-installs-python-bytecode usr/share/logentries/logentries/__init__.pyc
E: logentries: package-installs-python-bytecode usr/share/logentries/logentries/backports.pyc
E: logentries: package-installs-python-bytecode usr/share/logentries/logentries/formats.pyc
E: logentries: package-installs-python-bytecode usr/share/logentries/logentries/le.pyc
E: logentries: package-installs-python-bytecode usr/share/logentries/logentries/metrics.pyc
E: logentries: package-installs-python-bytecode usr/share/logentries/logentries/socks.pyc
E: logentries: package-installs-python-bytecode usr/share/logentries/logentries/utils.pyc
W: logentries: binary-without-manpage usr/bin/le
W: logentries: binary-without-manpage usr/bin/le-follow
W: logentries: binary-without-manpage usr/bin/le-init
W: logentries: binary-without-manpage usr/bin/le-ls
W: logentries: binary-without-manpage usr/bin/le-monitor
W: logentries: binary-without-manpage usr/bin/le-pull
W: logentries: binary-without-manpage usr/bin/le-push
W: logentries: binary-without-manpage usr/bin/le-reinit
W: logentries: binary-without-manpage usr/bin/le-rm
Finished running lintian.
logentries_1.4.41_all.deb
```